### PR TITLE
Make headings spacious via padding not margin

### DIFF
--- a/willowtest/typography.css
+++ b/willowtest/typography.css
@@ -12,7 +12,7 @@ strong {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  margin: 1.25em 0 0.5em 0;
+  padding: 1.25em 0 0.5em 0;
 }
 
 p {


### PR DESCRIPTION
This way, all links to the headings have a bit of spacing to the top, making everything feel less claustrophobic. There should be no visual changes, only the behaviour when following a link changes.