### PR TITLE
Working previews

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -81,7 +81,6 @@ Deno.serve(async (req: Request) => {
     return new Response(file.readable, {
       headers: {
         "Content-Type": contentKind,
-        "Access-Control-Allow-Origin": "*",
       },
     });
   }

--- a/server.ts
+++ b/server.ts
@@ -81,6 +81,7 @@ Deno.serve(async (req: Request) => {
     return new Response(file.readable, {
       headers: {
         "Content-Type": contentKind,
+        "Access-Control-Allow-Origin": "*",
       },
     });
   }

--- a/src/assets/pretty_previews.js
+++ b/src/assets/pretty_previews.js
@@ -1392,7 +1392,7 @@ function _(e, t) {
             $ = `${te[0]}?${ne.toString()}`;
         }
         let G = document.createElement("iframe");
-        G.setAttribute("sandbox", "allow-scripts"),
+        G.setAttribute("sandbox", "allow-scripts allow-same-origin"),
           G.src = $,
           L.appendChild(G),
           L.addEventListener("mouseleave", () => {


### PR DESCRIPTION
Issue is actually in the macromania-previews, we need to add the [`allow-same-origin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#allow-same-origin) token to the `sandbox` attribute:

> If this token is not used, the resource is treated as being from a special origin that always fails the [same-origin policy](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy) (potentially preventing access to [data storage/cookies](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).